### PR TITLE
patch #5

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 rodrigo toledo
+Copyright (c) 2020 - Present | rodrigo toledo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@
 
 ## :information_source: About
 
-With this scrapper you can get the new and coming soon releases `information` from junodownload website. Like the folowing
+With this scrapper you can get the `new` and `coming soon` releases `information` from junodownload website. Like the following:
 
-- Artist
-- Album name
-- Label
-- Cover
+| Information   | New Releases       | Coming Soon        |
+| ------------- | ------------------ | ------------------ |
+| Artist        | :heavy_check_mark: | :heavy_check_mark: |
+| Album (title) | :heavy_check_mark: | :heavy_check_mark: |
+| Label         | :heavy_check_mark: | :heavy_check_mark: |
+| Cover (url)   | :heavy_check_mark: | :heavy_check_mark: |
 
 <div align="center">
     <img src="docs/media/new_releases.png" alt="JunoDownload new releases"/>
@@ -47,25 +49,26 @@ pnpm install
 pnpm build
 ```
 
+```
+pnpm dev
+```
+
+or import this package
+
 ```JavaScript
 import { junoScrapper } from './dist/index.js';
 
 async function start() {
   try {
     const releases = await junoScrapper();
-    console.log(releases);
+    console.log(releases.get('New releases'));
+    console.log(releases.get('Coming soon'));
   } catch (err) {
     console.log(err);
   }
 }
 
 start().catch((err) => console.log(err));
-```
-
-or
-
-```
-pnpm dev
 ```
 
 #### :scroll: License
@@ -77,6 +80,7 @@ pnpm dev
 ```
     .
     ├── docs                    # Documentation files
+    ├── dev                     # Run the package as a dev
     ├── src                     # Source files
     └── README.md
 ```

--- a/dev/index.ts
+++ b/dev/index.ts
@@ -3,10 +3,11 @@ import { junoScrapper } from '../dist/index.js';
 async function start(): Promise<void> {
   try {
     const data = await junoScrapper();
-    console.log(data);
+    console.log(data.get('New releases'));
+    console.log(data.get('Coming soon'));
   } catch (err) {
     console.log(err);
   }
 }
 
-start().catch((err) => console.log(err));
+await start();

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-n": "^15.6.0",
     "eslint-plugin-promise": "^6.1.1",
     "husky": "^8.0.3",
-    "prettier": "^2.8.1",
+    "prettier": "^2.8.2",
     "tsx": "^3.12.1",
     "typescript": "^4.9.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ specifiers:
   eslint-plugin-n: ^15.6.0
   eslint-plugin-promise: ^6.1.1
   husky: ^8.0.3
-  prettier: ^2.8.1
+  prettier: ^2.8.2
   tsx: ^3.12.1
   typescript: ^4.9.4
 
@@ -30,7 +30,7 @@ devDependencies:
   eslint-plugin-n: 15.6.0_eslint@8.31.0
   eslint-plugin-promise: 6.1.1_eslint@8.31.0
   husky: 8.0.3
-  prettier: 2.8.1
+  prettier: 2.8.2
   tsx: 3.12.1
   typescript: 4.9.4
 
@@ -323,7 +323,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.5
+      es-abstract: 1.21.0
       get-intrinsic: 1.1.3
       is-string: 1.0.7
     dev: true
@@ -339,8 +339,13 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.5
+      es-abstract: 1.21.0
       es-shim-unscopables: 1.0.0
+    dev: true
+
+  /available-typed-arrays/1.0.5:
+    resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
+    engines: {node: '>= 0.4'}
     dev: true
 
   /balanced-match/1.0.2:
@@ -557,26 +562,31 @@ packages:
     engines: {node: '>=0.12'}
     dev: false
 
-  /es-abstract/1.20.5:
-    resolution: {integrity: sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==}
+  /es-abstract/1.21.0:
+    resolution: {integrity: sha512-GUGtW7eXQay0c+PRq0sGIKSdaBorfVqsCMhGHo4elP7YVqZu9nCZS4UkK4gv71gOWNMra/PaSKD3ao1oWExO0g==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
+      es-set-tostringtag: 2.0.1
       es-to-primitive: 1.2.1
       function-bind: 1.1.1
       function.prototype.name: 1.1.5
       get-intrinsic: 1.1.3
       get-symbol-description: 1.0.0
+      globalthis: 1.0.3
       gopd: 1.0.1
       has: 1.0.3
       has-property-descriptors: 1.0.0
+      has-proto: 1.0.1
       has-symbols: 1.0.3
       internal-slot: 1.0.4
+      is-array-buffer: 3.0.1
       is-callable: 1.2.7
       is-negative-zero: 2.0.2
       is-regex: 1.1.4
       is-shared-array-buffer: 1.0.2
       is-string: 1.0.7
+      is-typed-array: 1.1.10
       is-weakref: 1.0.2
       object-inspect: 1.12.2
       object-keys: 1.1.1
@@ -585,7 +595,18 @@ packages:
       safe-regex-test: 1.0.0
       string.prototype.trimend: 1.0.6
       string.prototype.trimstart: 1.0.6
+      typed-array-length: 1.0.4
       unbox-primitive: 1.0.2
+      which-typed-array: 1.1.9
+    dev: true
+
+  /es-set-tostringtag/2.0.1:
+    resolution: {integrity: sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      get-intrinsic: 1.1.3
+      has: 1.0.3
+      has-tostringtag: 1.0.0
     dev: true
 
   /es-shim-unscopables/1.0.0:
@@ -1166,6 +1187,12 @@ packages:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
     dev: true
 
+  /for-each/0.3.3:
+    resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
+    dependencies:
+      is-callable: 1.2.7
+    dev: true
+
   /fs.realpath/1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
@@ -1188,7 +1215,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.5
+      es-abstract: 1.21.0
       functions-have-names: 1.2.3
     dev: true
 
@@ -1248,6 +1275,13 @@ packages:
       type-fest: 0.20.2
     dev: true
 
+  /globalthis/1.0.3:
+    resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      define-properties: 1.1.4
+    dev: true
+
   /globby/11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
@@ -1283,6 +1317,11 @@ packages:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
     dependencies:
       get-intrinsic: 1.1.3
+    dev: true
+
+  /has-proto/1.0.1:
+    resolution: {integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==}
+    engines: {node: '>= 0.4'}
     dev: true
 
   /has-symbols/1.0.3:
@@ -1355,6 +1394,14 @@ packages:
       get-intrinsic: 1.1.3
       has: 1.0.3
       side-channel: 1.0.4
+    dev: true
+
+  /is-array-buffer/3.0.1:
+    resolution: {integrity: sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==}
+    dependencies:
+      call-bind: 1.0.2
+      get-intrinsic: 1.1.3
+      is-typed-array: 1.1.10
     dev: true
 
   /is-bigint/1.0.4:
@@ -1449,6 +1496,17 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
+    dev: true
+
+  /is-typed-array/1.1.10:
+    resolution: {integrity: sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      available-typed-arrays: 1.0.5
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      gopd: 1.0.1
+      has-tostringtag: 1.0.0
     dev: true
 
   /is-weakref/1.0.2:
@@ -1587,7 +1645,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.5
+      es-abstract: 1.21.0
     dev: true
 
   /once/1.4.0:
@@ -1676,8 +1734,8 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier/2.8.1:
-    resolution: {integrity: sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==}
+  /prettier/2.8.2:
+    resolution: {integrity: sha512-BtRV9BcncDyI2tsuS19zzhzoxD8Dh8LiCx7j7tHzrkz8GFXAexeWFdi22mjE1d16dftH2qNaytVxqiRTGlMfpw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     dev: true
@@ -1795,7 +1853,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.5
+      es-abstract: 1.21.0
     dev: true
 
   /string.prototype.trimstart/1.0.6:
@@ -1803,7 +1861,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.5
+      es-abstract: 1.21.0
     dev: true
 
   /strip-ansi/6.0.1:
@@ -1892,6 +1950,14 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /typed-array-length/1.0.4:
+    resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
+    dependencies:
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      is-typed-array: 1.1.10
+    dev: true
+
   /typescript/4.9.4:
     resolution: {integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==}
     engines: {node: '>=4.2.0'}
@@ -1921,6 +1987,18 @@ packages:
       is-number-object: 1.0.7
       is-string: 1.0.7
       is-symbol: 1.0.4
+    dev: true
+
+  /which-typed-array/1.1.9:
+    resolution: {integrity: sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      available-typed-arrays: 1.0.5
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      gopd: 1.0.1
+      has-tostringtag: 1.0.0
+      is-typed-array: 1.1.10
     dev: true
 
   /which/2.0.2:

--- a/src/core/cheerio.ts
+++ b/src/core/cheerio.ts
@@ -1,5 +1,12 @@
 import * as cheerio from 'cheerio';
-import { ARTISTCLASSNAME, COVERCLASSNAME, LABELCLASSNAME, TITLECLASSNAME } from './constants.js';
+import {
+  ARTISTCLASSNAME,
+  COVERCLASSNAME,
+  CSCLASSNAME,
+  LABELCLASSNAME,
+  NRCLASSNAME,
+  TITLECLASSNAME,
+} from './constants.js';
 
 export interface Release {
   artist: string;
@@ -10,7 +17,6 @@ export interface Release {
 
 /**
  * Returns the cheerio object loaded with the current plain html text.
- *
  * @param html - Plain html text.
  * @returns cheerio object.
  */
@@ -20,20 +26,23 @@ export function loadHTML(html: string): cheerio.CheerioAPI {
 }
 
 /**
- * Returns an array of objects with release information.
- *
- * @param a - cheerio object.
- * @param classname - input of the classname to scrap.
+ * Returns an array of objects with releases.
+ * @param c - cheerio object.
+ * @param isNewRelease - boolean, if it's true return `new releases` otherwise `coming soon releases`.
  */
-export function getReleases(a: cheerio.CheerioAPI, classname: string): Release[] {
+export function getReleases(c: cheerio.CheerioAPI, isNewRelease: boolean): Release[] {
   const releases: Release[] = [];
-  const scrapReleases = a(classname);
+  let classname: string;
+
+  isNewRelease ? (classname = NRCLASSNAME) : (classname = CSCLASSNAME);
+
+  const scrapReleases = c(classname);
 
   scrapReleases.each((_i, release) => {
-    const artist = a(release).find(ARTISTCLASSNAME).text();
-    const title = a(release).find(TITLECLASSNAME).text();
-    const label = a(release).find(LABELCLASSNAME).text();
-    const cover = a(release).find(COVERCLASSNAME).attr('data-src');
+    const artist = c(release).find(ARTISTCLASSNAME).text();
+    const title = c(release).find(TITLECLASSNAME).text();
+    const label = c(release).find(LABELCLASSNAME).text();
+    const cover = c(release).find(COVERCLASSNAME).attr('data-src');
 
     releases.push({ artist, title, label, cover });
   });

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,16 +1,22 @@
 import { getReleases, loadHTML, type Release } from './cheerio.js';
-import { CSCLASSNAME, JUNOSITE, NRCLASSNAME } from './constants.js';
+import { JUNOSITE } from './constants.js';
 import { fetcher } from './fetcher.js';
 
+type JunoRelease = 'Coming soon' | 'New releases';
+
 /**
- * Returns an object with coming soon & new releases
- *
+ * Returns a Map object with `Coming soon` & `New releases`
  */
-export async function junoScrapper(): Promise<{ comingSoon: Release[]; newReleases: Release[] }> {
+export async function junoScrapper(): Promise<Map<JunoRelease, Release[]>> {
+  const junoReleases: Map<JunoRelease, Release[]> = new Map();
+
   const response = await fetcher(JUNOSITE);
   const cheerioLoaded = loadHTML(response);
-  const comingSoon = getReleases(cheerioLoaded, CSCLASSNAME);
-  const newReleases = getReleases(cheerioLoaded, NRCLASSNAME);
+  const newReleases = getReleases(cheerioLoaded, true);
+  const comingSoon = getReleases(cheerioLoaded, false);
 
-  return { comingSoon, newReleases };
+  junoReleases.set('Coming soon', comingSoon);
+  junoReleases.set('New releases', newReleases);
+
+  return junoReleases;
 }


### PR DESCRIPTION
- Instead of returning and object, use [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)
- handle `classname` selection in `getReleases` function instead of `junoScrapper`
- update docs
- bump deps